### PR TITLE
Fix git reset parameter

### DIFF
--- a/lib/gisdatigo/git_manager.rb
+++ b/lib/gisdatigo/git_manager.rb
@@ -54,7 +54,7 @@ module Gisdatigo
     end
 
     def reset
-      @repository.reset(@repository.head, :hard)
+      @repository.reset('HEAD', :hard)
     end
   end
 end

--- a/spec/git_manager_spec.rb
+++ b/spec/git_manager_spec.rb
@@ -167,11 +167,7 @@ describe Gisdatigo::GitManager do
 
       describe 'reset' do
         subject { Gisdatigo::GitManager.new }
-        let(:head) { mock('head') }
-
-        before do
-          rugged_repository.expects(:head).returns(head)
-        end
+        let(:head) { 'HEAD' }
 
         it 'is expected to perform a hard git reset to HEAD' do
           rugged_repository.expects(:reset).with(head, :hard)


### PR DESCRIPTION
When the tests of the repository being updated by gisdatigo failed,
there was a stacktrace left by Rugged, and the Gemfile.lock was left
half staged on git status. The raised error was:

 TypeError (wrong argument type Rugged::Reference (expected String))

Passing the string 'HEAD' instead of the rugged object seems to work as
intended.