### PR TITLE
Add executable CLI

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@ Very opinionated automation for most of the gem update process for Rails applica
 
 ## Unreleased
 
+* Add CLI
+
 ## v0.3.2 - 07/06/2020
 
 * Fix release mistakes (sorry)

--- a/bin/gisdatigo
+++ b/bin/gisdatigo
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'cli'
+
+CLI.run ARGV

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -1,0 +1,27 @@
+require 'optparse'
+require "gisdatigo"
+require "gisdatigo/version"
+
+module CLI
+  def CLI.run(args)
+    options = CLI.parse_options(args)
+
+    Gisdatigo.configure_with('.gisdatigo') if File.exists?('.gisdatigo')
+
+    Gisdatigo::Runner.run
+  end
+
+  def CLI.parse_options(args)
+    OptionParser.new do |parser|
+      parser.on_tail('-h', '--help', 'Show this message') do
+        Kernel.puts parser
+        Kernel.exit
+      end
+
+      parser.on_tail('-V', '--version', 'Print version and exit') do
+        Kernel.puts Gisdatigo::VERSION
+        Kernel.exit
+      end
+    end.parse(args)
+  end
+end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+require 'cli'
+
+describe CLI do
+  describe 'run' do
+    let(:args) { [] }
+
+    it 'is expected to parse the options and call the runner' do
+      described_class.expects(:parse_options).with(args)
+      File.expects(:exists?).with('.gisdatigo').returns(true)
+      Gisdatigo.expects(:configure_with).with('.gisdatigo')
+      Gisdatigo::Runner.expects(:run)
+
+      described_class.run args
+    end
+  end
+
+  describe 'parse_options' do
+    let(:args) { [] }
+
+    context 'when passing the help flag' do
+      let(:args) { ['--help'] }
+      let(:message) { '' }
+
+      it 'is expected to print a message and exit' do
+        Kernel.expects(:puts).with(instance_of(OptionParser))
+        Kernel.expects(:exit)
+
+        described_class.parse_options(args)
+      end
+    end
+
+    context 'when passing the version flag' do
+      let(:args) { ['--version'] }
+      let(:message) { '' }
+
+      it 'is expected to print a message and exit' do
+        Kernel.expects(:puts).with(Gisdatigo::VERSION)
+        Kernel.expects(:exit)
+
+        described_class.parse_options(args)
+      end
+    end
+
+    context 'with no arguments' do
+      let(:args) { [] }
+
+      it 'is expected to be return empty options' do
+        expect(described_class.parse_options(args).to_a).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before this, the only supported way of running gisdatigo was by using a
rake task loaded as a railtie. This made things a bit less
straightforward for running, since we had to add the gisdatigo gem to
the Gemfile to be able to run, and in case we wanted to use it ti update
a non rails application, there was no way to do it. Now, even in a non
rails app, running 'gem install gisdatigo;gisdatigo' should be enough to
get things running.

Part of #10.